### PR TITLE
Flexible Polars version & polars example fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 serde = ">=1.0.210"
 statrs = ">=0.17.1"
-polars = "0.43.1"
+polars = ">=0.43.1"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Here are some examples of running tests with Rust.
 use polars::prelude::*;
 use hypors::{t::t_test, common::TailType};
 
-let data = Series::new("sample", &[1.2, 2.3, 1.9, 2.5, 2.8]);
+let data = Series::new("sample".into(), &[1.2, 2.3, 1.9, 2.5, 2.8]);
 let population_mean = 2.0;
 let tail = TailType::Two;
 let alpha = 0.05;

--- a/hypopy/anova/one_way.rs
+++ b/hypopy/anova/one_way.rs
@@ -32,9 +32,9 @@ use std::f64;
 /// use polars::prelude::*;
 ///
 /// // Define data for three independent groups
-/// let data1 = Series::new("Group1", vec![2.0, 3.0, 3.0, 5.0, 6.0]);
-/// let data2 = Series::new("Group2", vec![3.0, 4.0, 4.0, 6.0, 8.0]);
-/// let data3 = Series::new("Group3", vec![5.0, 6.0, 7.0, 8.0, 9.0]);
+/// let data1 = Series::new("Group1".into(), vec![2.0, 3.0, 3.0, 5.0, 6.0]);
+/// let data2 = Series::new("Group2".into(), vec![3.0, 4.0, 4.0, 6.0, 8.0]);
+/// let data3 = Series::new("Group3".into(), vec![5.0, 6.0, 7.0, 8.0, 9.0]);
 ///
 /// // Perform ANOVA
 /// let result = anova(&[&data1, &data2, &data3], 0.05).unwrap();
@@ -117,12 +117,13 @@ pub fn py_anova(data_groups: Vec<Py<Series>>, alpha: f64) -> PyResult<TestResult
             .map(|s| s.extract::<Series>(py))
             .collect();
 
-            let groups = groups?; // Propagate any extraction errors
+        let groups = groups?; // Propagate any extraction errors
 
-            // Now you have a Vec<Series> which can be used in your ANOVA function.
-            let groups_slice: Vec<&Series> = groups.iter().collect(); // Create a slice of references to Series
+        // Now you have a Vec<Series> which can be used in your ANOVA function.
+        let groups_slice: Vec<&Series> = groups.iter().collect(); // Create a slice of references to Series
 
         // Call the ANOVA function with the slice
-        anova(groups_slice, alpha).map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+        anova(groups_slice, alpha)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
     })
 }

--- a/src/anova/mod.rs
+++ b/src/anova/mod.rs
@@ -22,9 +22,9 @@
 //! use polars::prelude::*;
 //!
 //! // Sample data groups
-//! let group1 = Series::new("Group 1", vec![2.0, 3.0, 3.0, 5.0, 6.0]);
-//! let group2 = Series::new("Group 2", vec![3.0, 4.0, 4.0, 6.0, 8.0]);
-//! let group3 = Series::new("Group 3", vec![5.0, 6.0, 7.0, 8.0, 9.0]);
+//! let group1 = Series::new("Group 1".into(), vec![2.0, 3.0, 3.0, 5.0, 6.0]);
+//! let group2 = Series::new("Group 2".into(), vec![3.0, 4.0, 4.0, 6.0, 8.0]);
+//! let group3 = Series::new("Group 3".into(), vec![5.0, 6.0, 7.0, 8.0, 9.0]);
 //!
 //! // Perform one-way ANOVA
 //! let result = anova(&[&group1, &group2, &group3], 0.05).unwrap();

--- a/src/anova/one_way.rs
+++ b/src/anova/one_way.rs
@@ -36,9 +36,9 @@ use std::f64;
 /// use polars::prelude::*;
 ///
 /// // Define data for three independent groups
-/// let data1 = Series::new("Group1", vec![2.0, 3.0, 3.0, 5.0, 6.0]);
-/// let data2 = Series::new("Group2", vec![3.0, 4.0, 4.0, 6.0, 8.0]);
-/// let data3 = Series::new("Group3", vec![5.0, 6.0, 7.0, 8.0, 9.0]);
+/// let data1 = Series::new("Group1".into(), vec![2.0, 3.0, 3.0, 5.0, 6.0]);
+/// let data2 = Series::new("Group2".into(), vec![3.0, 4.0, 4.0, 6.0, 8.0]);
+/// let data3 = Series::new("Group3".into(), vec![5.0, 6.0, 7.0, 8.0, 9.0]);
 ///
 /// // Perform ANOVA
 /// let result = anova(&[&data1, &data2, &data3], 0.05).unwrap();

--- a/src/chi_square/categorical.rs
+++ b/src/chi_square/categorical.rs
@@ -109,8 +109,8 @@ pub fn independence(contingency_table: &[Vec<f64>], alpha: f64) -> Result<TestRe
 /// use polars::prelude::*;
 ///
 /// // Observed and expected frequencies
-/// let observed = Series::new("Observed", vec![30.0, 10.0, 20.0]);
-/// let expected = Series::new("Expected", vec![25.0, 15.0, 20.0]);
+/// let observed = Series::new("Observed".into(), vec![30.0, 10.0, 20.0]);
+/// let expected = Series::new("Expected".into(), vec![25.0, 15.0, 20.0]);
 /// let alpha = 0.05;
 ///
 /// // Perform Chi-Square Goodness of Fit Test

--- a/src/chi_square/variance.rs
+++ b/src/chi_square/variance.rs
@@ -30,7 +30,7 @@ use statrs::distribution::ChiSquared;
 /// use polars::prelude::*;
 ///
 /// // Sample data
-/// let data = Series::new("data", vec![4.0, 5.0, 6.0, 7.0, 8.0]);
+/// let data = Series::new("data".into(), vec![4.0, 5.0, 6.0, 7.0, 8.0]);
 /// let pop_variance = 2.0; // Hypothesized population variance
 /// let alpha = 0.05; // Significance level
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! use polars::prelude::*;
 //! use hypors::{t::one_sample, common::TailType};
 //!
-//! let data = Series::new("sample", &[1.2, 2.3, 1.9, 2.5, 2.8]);
+//! let data = Series::new("sample".into(), &[1.2, 2.3, 1.9, 2.5, 2.8]);
 //! let population_mean = 2.0;
 //! let tail = TailType::Two;
 //! let alpha = 0.05;
@@ -52,7 +52,7 @@
 //! use polars::prelude::*;
 //! use hypors::{z::one_sample_z, common::TailType};
 //!
-//! let data = Series::new("sample", &[1.5, 2.3, 2.7, 2.8, 3.1]);
+//! let data = Series::new("sample".into(), &[1.5, 2.3, 2.7, 2.8, 3.1]);
 //! let population_mean = 2.0;
 //! let population_std_dev = 0.5;
 //! let tail = TailType::Two;
@@ -105,9 +105,9 @@
 //! use polars::prelude::*;
 //! use hypors::anova::one_way_anova;
 //!
-//! let group1 = Series::new("Group 1", &[1.5, 2.5, 1.8]);
-//! let group2 = Series::new("Group 2", &[2.3, 2.9, 3.0]);
-//! let group3 = Series::new("Group 3", &[1.9, 2.2, 2.5]);
+//! let group1 = Series::new("Group 1".into(), &[1.5, 2.5, 1.8]);
+//! let group2 = Series::new("Group 2".into(), &[2.3, 2.9, 3.0]);
+//! let group3 = Series::new("Group 3".into(), &[1.9, 2.2, 2.5]);
 //!
 //! let result = one_way_anova(&[group1, group2, group3]).unwrap();
 //! println!("F Statistic: {}", result.f_statistic);
@@ -150,8 +150,8 @@
 //! use polars::prelude::*;
 //! use hypors::mann_whitney::mann_whitney_u;
 //!
-//! let group1 = Series::new("Group 1", &[1.2, 2.3, 3.1]);
-//! let group2 = Series::new("Group 2", &[2.5, 3.0, 3.8]);
+//! let group1 = Series::new("Group 1".into(), &[1.2, 2.3, 3.1]);
+//! let group2 = Series::new("Group 2".into(), &[2.5, 3.0, 3.8]);
 //!
 //! let result = mann_whitney_u(&group1, &group2).unwrap();
 //! println!("U Statistic: {}", result.u_statistic);

--- a/src/mann_whitney/u.rs
+++ b/src/mann_whitney/u.rs
@@ -35,8 +35,8 @@ use std::f64;
 /// use crate::mann_whitney::u_test;
 ///
 /// fn main() -> Result<(), PolarsError> {
-///     let data1 = Series::new("group1", vec![1.0, 2.0, 3.0, 4.0]);
-///     let data2 = Series::new("group2", vec![2.5, 3.5, 4.5]);
+///     let data1 = Series::new("group1".into(), vec![1.0, 2.0, 3.0, 4.0]);
+///     let data2 = Series::new("group2".into(), vec![2.5, 3.5, 4.5]);
 ///     let alpha = 0.05;
 ///
 ///     let result = u_test(&data1, &data2, alpha, TailType::Two)?;

--- a/src/proportion/one_sample.rs
+++ b/src/proportion/one_sample.rs
@@ -29,7 +29,7 @@ use statrs::distribution::Normal;
 /// use polars::prelude::*;
 /// use hypors::{proportion::z_test, TailType};
 ///
-/// let series = Series::new("data", &[1, 0, 1, 1, 0]);
+/// let series = Series::new("data".into(), &[1, 0, 1, 1, 0]);
 /// let pop_proportion = 0.5;
 /// let tail = TailType::Two;
 /// let alpha = 0.05;

--- a/src/proportion/two_sample.rs
+++ b/src/proportion/two_sample.rs
@@ -30,8 +30,8 @@ use statrs::distribution::Normal;
 /// use polars::prelude::*;
 /// use hypors::{proportion::z_test_ind, TailType};
 ///
-/// let series1 = Series::new("data1", &[1, 0, 1, 1, 0]);
-/// let series2 = Series::new("data2", &[0, 0, 1, 1, 1]);
+/// let series1 = Series::new("data1".into(), &[1, 0, 1, 1, 0]);
+/// let series2 = Series::new("data2".into(), &[0, 0, 1, 1, 1]);
 /// let tail = TailType::Two;
 /// let alpha = 0.05;
 /// let pooled = true; // Use pooled proportions

--- a/src/t/one_sample.rs
+++ b/src/t/one_sample.rs
@@ -29,7 +29,7 @@ use statrs::distribution::StudentsT;
 /// use polars::prelude::*;
 /// use hypors::{t_test, TailType};
 ///
-/// let series = Series::new("data", &[1.2, 2.3, 1.9, 2.5, 2.8]);
+/// let series = Series::new("data".into(), &[1.2, 2.3, 1.9, 2.5, 2.8]);
 /// let pop_mean = 2.0;
 /// let tail = TailType::Two; // Two-tailed test
 /// let alpha = 0.05; // 5% significance level

--- a/src/t/two_sample.rs
+++ b/src/t/two_sample.rs
@@ -30,8 +30,8 @@ use statrs::distribution::StudentsT;
 /// use polars::prelude::*;
 /// use hypors::{t_test_paired, TailType};
 ///
-/// let series1 = Series::new("data1", &[1.2, 2.3, 1.9, 2.5, 2.8]);
-/// let series2 = Series::new("data2", &[1.1, 2.0, 1.7, 2.3, 2.6]);
+/// let series1 = Series::new("data1".into(), &[1.2, 2.3, 1.9, 2.5, 2.8]);
+/// let series2 = Series::new("data2".into(), &[1.1, 2.0, 1.7, 2.3, 2.6]);
 /// let tail = TailType::Two; // Two-tailed test
 /// let alpha = 0.05; // 5% significance level
 ///
@@ -95,8 +95,8 @@ pub fn t_test_paired(
 /// use polars::prelude::*;
 /// use hypors::{t_test_ind, TailType};
 ///
-/// let series1 = Series::new("data1", &[1.2, 2.3, 1.9, 2.5, 2.8]);
-/// let series2 = Series::new("data2", &[1.1, 2.0, 1.7, 2.3, 2.6]);
+/// let series1 = Series::new("data1".into(), &[1.2, 2.3, 1.9, 2.5, 2.8]);
+/// let series2 = Series::new("data2".into(), &[1.1, 2.0, 1.7, 2.3, 2.6]);
 /// let tail = TailType::Two; // Two-tailed test
 /// let alpha = 0.05; // 5% significance level
 /// let pooled = false; // Use Welch's t-test

--- a/src/z/mod.rs
+++ b/src/z/mod.rs
@@ -32,7 +32,7 @@
 //! use hypors::z::{z_test, z_test_ind, TailType};
 //!
 //! // Example for a one-sample Z-test
-//! let series = Series::new("data", &[10.0, 12.0, 14.0]);
+//! let series = Series::new("data".into(), &[10.0, 12.0, 14.0]);
 //! let pop_mean = 11.0; // Known population mean
 //! let pop_std = 2.0; // Known population standard deviation
 //! let tail = TailType::Two; // Two-tailed test
@@ -42,8 +42,8 @@
 //! let result_one_sample = z_test(&series, pop_mean, pop_std, tail, alpha).unwrap();
 //!
 //! // Example for an independent Z-test
-//! let series1 = Series::new("group1", &[5.0, 6.0, 7.0]);
-//! let series2 = Series::new("group2", &[8.0, 9.0, 10.0]);
+//! let series1 = Series::new("group1".into(), &[5.0, 6.0, 7.0]);
+//! let series2 = Series::new("group2".into(), &[8.0, 9.0, 10.0]);
 //! let pop_std1 = 1.0; // Population standard deviation for group 1
 //! let pop_std2 = 1.0; // Population standard deviation for group 2
 //!


### PR DESCRIPTION
Very cool crate! 

# Goal

Unpin the version of Polars to be more flexible and make the Polars Rust ecosystem more compatible.

# Issue

When the `Polars` version is pinned (like to `0.43.1` in this crate), it makes it impossible to work between many crates. For example, this code below does not work because `hypors` pins `Polars` to `0.43.1` and `Plotlars` pins `Polars` to `0.45.1`, making Polars incompatible (and I need `0.46` for my project). Using the first Cargo.toml, it throws an error and suggests `perhaps two different versions of crate polars_core are being used?`. Using the second (with this pull request and a similar pull request for [Plotlars](https://github.com/alceal/plotlars/pull/36) there is no issue since both crates are actually compatible with Polars 0.46.

Example code using Polars, Hypors and Plotlars: 

```Rust
use hypors::anova::anova;
use plotlars::{Plot, Rgb, ScatterPlot};
use polars::prelude::*;

fn main() {
    // https://github.com/alceal/plotlars/blob/main/data/penguins.csv
    let lf = LazyCsvReader::new("./penguins.csv")
        .with_has_header(true)
        .finish()
        .unwrap();

    // Plot to explore the data
    let html = ScatterPlot::builder()
        .data(&lf.clone().collect().unwrap())
        .x("body_mass_g")
        .y("flipper_length_mm")
        .group("species")
        .opacity(0.5)
        .size(12)
        .colors(vec![Rgb(178, 34, 34), Rgb(65, 105, 225), Rgb(255, 140, 0)])
        .plot_title("Penguin Flipper Length vs Body Mass")
        .x_title("Body Mass (g)")
        .y_title("Flipper Length (mm)")
        .legend_title("Species")
        .build()
        .to_html();

    // Write HTML
    let mut file = std::fs::File::create("./plot.html").unwrap();
    std::io::Write::write_all(&mut file, html.as_bytes()).unwrap();

    // Reduce lf to only needed variables and process vars
    let lf = lf
        .select([
            col("species"),
            col("flipper_length_mm").cast(DataType::Float64),
        ])
        .filter(col("flipper_length_mm").is_not_null())
        .with_row_index("index", None);

    // Transpose for ANOVA
    let df = pivot::pivot_stable(
        &lf.collect().unwrap(),
        ["species"],
        Some(["index"]),
        Some(["flipper_length_mm"]),
        false,
        None,
        None,
    )
    .unwrap()
    .drop("index")
    .unwrap();

    // Create Vec<Series> for ANOVA
    let cols: Vec<Series> = df
        .get_columns()
        .iter()
        .map(|c| c.as_materialized_series().to_float().unwrap().drop_nulls())
        .collect();

    // Perform one-way ANOVA
    let result = anova(&[&cols[0], &cols[1], &cols[2]], 0.05).unwrap();

    println!(
        "\nF-statistic: {}\np-value: {}\n",
        result.test_statistic, result.p_value
    );
}
```

`Cargo.toml` no. 1:

```toml
polars = { version = "0.46", features = ["lazy", "parquet", "pivot"] }
hypors = "0.2.5"
plotlars = "0.8.1"
```


`Cargo.toml` no. 2:

```toml
polars = { version = "0.46", features = ["lazy", "parquet", "pivot"] }
hypors = {git = "https://github.com/EricFecteau/hypors.git", branch = "Update-Polars" }
plotlars = {git = "https://github.com/EricFecteau/plotlars.git", branch = "update_polars" }
```

Other comments:

I also fixed the examples with `.into()` for Polars `Series` (this was necessary for `0.43.1` also). And, I also updated `cargo.toml` to `Cargo.toml` otherwise I could not build it at all.

While testing (to see if the crate was compatible with `Polars = 0.46` (it is by the way)), two tests would not pass (even before I updated Polars). Here is info on why:
* `test_f_sample_size`: My difference between `n` and `expected_sample_size` is exactly `1.0`, so the `assert!((n - expected_sample_size).abs() =  1.0);` fails.
* `test_calculate_chi2_ci`: My value of `ci` is `(0.5913965895542996, 4.166065673148933)`, slightly more different than the `EPSILON` difference between the expected value and the computed value.

Also, all your doctests do not build at all and I am not sure why. If it's intentional, I recommend adding `doctest = false` under `[lib]` in the `Cargo.toml` to skip these tests.

Again, very cool crate!

