### PR TITLE
Make clippy a strict CI gate and declare the MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,8 @@ jobs:
       - name: Formatting
         run: cargo fmt --check
 
-      # bool_assert_comparison is allowed only because the existing
-      # integration tests trip it 14 times; drop the -A once those are
-      # cleaned up so every clippy lint is a hard failure.
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings -A clippy::bool_assert_comparison
+        run: cargo clippy --all-targets -- -D warnings
 
       # Plain `cargo test` on purpose: it runs the unit, integration and
       # doc tests. `--all-targets` would silently drop the doc tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "hypors"
 authors = ["Shubhankar Agrawal <shubhankar.a31@gmail.com>"]
 version = "0.3.0"
 edition = "2024"
+rust-version = "1.85"        # edition 2024 requires 1.85+
 license-file = "LICENSE"
 repository = "https://github.com/astronights/hypors"
 description = "Hypothesis Testing with Rust"

--- a/tests/anova.rs
+++ b/tests/anova.rs
@@ -19,7 +19,7 @@ mod tests_anova {
 
         assert!((result.test_statistic - expected_f_statistic).abs() < EPSILON);
         assert!((result.p_value - expected_p_value).abs() < EPSILON);
-        assert_eq!(result.reject_null, true);
+        assert!(result.reject_null);
 
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
@@ -40,7 +40,7 @@ mod tests_anova {
 
         assert!((result.test_statistic - expected_f_statistic).abs() < EPSILON);
         assert!((result.p_value - expected_p_value).abs() < EPSILON);
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
 
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);

--- a/tests/chi_square.rs
+++ b/tests/chi_square.rs
@@ -27,7 +27,7 @@ mod tests_chi_square {
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
     }
 
     #[test]
@@ -48,7 +48,7 @@ mod tests_chi_square {
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
-        assert_eq!(result.reject_null, true);
+        assert!(result.reject_null);
     }
 
     #[test]
@@ -71,7 +71,7 @@ mod tests_chi_square {
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
     }
 
     #[test]

--- a/tests/mann_whitney.rs
+++ b/tests/mann_whitney.rs
@@ -26,7 +26,7 @@ mod tests_mann_whitney {
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
     }
 
     #[test]
@@ -47,7 +47,7 @@ mod tests_mann_whitney {
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
     }
 
     #[test]

--- a/tests/proportion.rs
+++ b/tests/proportion.rs
@@ -24,7 +24,7 @@ mod tests_proportion {
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
     }
 
     #[test]
@@ -46,7 +46,7 @@ mod tests_proportion {
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
     }
 
     #[test]
@@ -68,7 +68,7 @@ mod tests_proportion {
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
     }
 
     #[test]

--- a/tests/t.rs
+++ b/tests/t.rs
@@ -22,7 +22,7 @@ mod tests_t_test {
 
         assert!((result.test_statistic - expected_t_statistic).abs() < EPSILON);
         assert!((result.p_value - expected_p_value).abs() < EPSILON);
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
         assert_eq!(result.null_hypothesis, expected_null_hypothesis);
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 

--- a/tests/z.rs
+++ b/tests/z.rs
@@ -23,7 +23,7 @@ mod tests_z_test {
 
         assert!((result.test_statistic - expected_z_statistic).abs() < EPSILON);
         assert!((result.p_value - expected_p_value).abs() < EPSILON);
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
 
         assert!((result.confidence_interval.0 - expected_ci_lower).abs() < EPSILON);
         assert!((result.confidence_interval.1 - expected_ci_upper).abs() < EPSILON);
@@ -50,7 +50,7 @@ mod tests_z_test {
 
         assert!((result.test_statistic - expected_z_statistic).abs() < EPSILON);
         assert!((result.p_value - expected_p_value).abs() < EPSILON);
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
 
         println!("{} {}", result.confidence_interval.0, expected_ci_lower);
         println!("{} {}", result.confidence_interval.1, expected_ci_upper);
@@ -81,7 +81,7 @@ mod tests_z_test {
 
         assert!((result.test_statistic - expected_z_statistic).abs() < EPSILON);
         assert!((result.p_value - expected_p_value).abs() < EPSILON);
-        assert_eq!(result.reject_null, false);
+        assert!(!result.reject_null);
 
         assert!((result.confidence_interval.0 - expected_ci_lower).abs() < EPSILON);
         assert!((result.confidence_interval.1 - expected_ci_upper).abs() < EPSILON);


### PR DESCRIPTION
Follow-up to #8, now that #7 has merged and no longer conflicts with the test files.

## Clippy is now a hard gate

`.github/workflows/ci.yml` carried an exemption:

```yaml
run: cargo clippy --all-targets -- -D warnings -A clippy::bool_assert_comparison
```

That `-A` was only there because the integration tests tripped `bool_assert_comparison` 14 times. `cargo clippy --fix` rewrote all 14 — `assert_eq!(x, true)` → `assert!(x)`, `assert_eq!(x, false)` → `assert!(!x)` — across `anova.rs` (2), `chi_square.rs` (3), `mann_whitney.rs` (2), `proportion.rs` (3), `t.rs` (1) and `z.rs` (3). Mechanical rewrites only; no assertion changed meaning, and none were dropped. The exemption is removed, so every clippy lint now fails CI rather than all-but-one.

Beyond satisfying the lint, `assert!` also gives a better failure message — `assert_eq!` on booleans prints `left: false, right: false`, which says nothing about what was being tested.

## MSRV declared

`rust-version = "1.85"` added to `Cargo.toml` — the minimum for `edition = "2024"`. Without it, a user on an older toolchain gets a confusing edition error instead of a clear MSRV message.

This was verified rather than assumed: I installed 1.85.0 and ran the full suite on it. Worth recording why it works, since a first attempt suggested otherwise — the current `statrs` 0.19.1 requires rustc 1.89, but because the dependency floor is `>=0.17.1`, cargo's MSRV-aware resolver (edition 2024 implies resolver 3) selects **statrs 0.18.0** and **nalgebra 0.33.3** on 1.85, and everything compiles and passes. Anyone on 1.89+ still gets 0.19.1. If `statrs` is ever pinned tightly, the MSRV rises to 1.89 with it.

## Verification

On stable, exactly as CI runs:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean, with no exemption
- `cargo test` — 9 suites green, including all 46 doctests
- `cargo package` — 41 files, verify build clean

On 1.85.0: all 9 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf)_