### PR TITLE
Release 0.4.0: unified error type, changelog, docs fixes, and a gated publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+# Tags only — never a merge to main. A crates.io publish cannot be undone
+# (a version can be yanked but never replaced), so releasing stays a
+# deliberate act rather than a side effect of merging.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    name: Verify tag and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # A tag that disagrees with the manifest would publish the wrong
+      # version or fail halfway through the release, so check it first.
+      - name: Tag matches Cargo.toml version
+        run: |
+          manifest="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          tag="${GITHUB_REF_NAME#v}"
+          echo "manifest=$manifest tag=$tag"
+          if [ "$manifest" != "$tag" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match Cargo.toml version $manifest"
+            exit 1
+          fi
+
+      - name: Tests
+        run: cargo test
+
+      - name: Package
+        run: cargo package
+
+  publish:
+    name: Publish to crates.io
+    needs: verify
+    runs-on: ubuntu-latest
+    # The crates-io environment holds CARGO_REGISTRY_TOKEN and a required
+    # reviewer, so this job waits for a human to approve the deployment and
+    # no other job can read the token.
+    environment: crates-io
+    permissions:
+      contents: write # creating the GitHub Release
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          awk -v tag="${GITHUB_REF_NAME#v}" '
+            $0 ~ "^## \\[" tag "\\]" { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+While this crate is pre-1.0, the **minor** version carries breaking changes:
+a dependency on `0.3` will not resolve to `0.4`.
+
+## [0.4.0] - 2026-09-07
+
+### Changed
+
+- **Mann-Whitney U p-values now match `scipy.stats.mannwhitneyu`
+  (`method="asymptotic"`).** Existing p-values change, and one-sided results
+  change substantially. Thanks to @guilherme-n-l (#7, reported in #6).
+  - The variance carries the tie correction
+    `n1*n2/12 * ((N + 1) - sum(t^3 - t) / (N * (N - 1)))`. The previous
+    no-ties variance overestimated sigma and inflated p-values on tied data.
+  - A 0.5 continuity correction is applied toward the tail, matching scipy's
+    default `use_continuity=True`.
+  - One-sided p-values derive from `U1` rather than `min(U1, U2)`. The old
+    statistic was sign-blind, so `TailType::Right` and `TailType::Left`
+    returned identical p-values regardless of which group dominated.
+  - When every observation is tied the variance is zero: the two-sided
+    p-value is now `NaN` and the one-sided p-values are `1.0`, matching
+    scipy 1.18's signed continuity correction. Previously this returned
+    `1.0` two-sided and `0.5` one-sided.
+- `test_statistic` is documented explicitly as `min(U1, U2)` while the
+  p-value derives from `U1`, so compare p-values rather than statistics
+  when checking against scipy.
+
+### Added
+
+- `rust-version = "1.85"`, the minimum supported Rust version for
+  edition 2024.
+- GitHub Actions CI running `cargo fmt --check`,
+  `cargo clippy --all-targets -- -D warnings`, `cargo test` (doc tests
+  included) and `cargo package` on every pull request (#8, #9).
+
+### Fixed
+
+- The manifest is named `Cargo.toml` rather than `cargo.toml`, which only
+  resolved on case-insensitive filesystems and broke every cargo command on
+  Linux (#8).
+
+### Internal
+
+- The published crate no longer ships the Python bindings (`hypopy`),
+  `py_tests`, or the CI configuration — 54 files down to 41 (#8).
+
+## [0.3.0] - 2025-04-19
+
+See the [release history](https://github.com/astronights/hypors/releases) for
+versions before this changelog was introduced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ a dependency on `0.3` will not resolve to `0.4`.
 - `test_statistic` is documented explicitly as `min(U1, U2)` while the
   p-value derives from `U1`, so compare p-values rather than statistics
   when checking against scipy.
+- **`mann_whitney::u_test` and `chi_square::variance` now return
+  `Result<TestResult, StatError>`** instead of `Result<TestResult, String>`,
+  matching every other test in the crate. Code matching on the error needs
+  updating; code using `?` or `unwrap()` does not. Empty input now yields
+  `StatError::EmptyData`, too few observations `StatError::InsufficientData`,
+  and distribution failures `StatError::ComputeError`.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hypors"
 authors = ["Shubhankar Agrawal <shubhankar.a31@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"        # edition 2024 requires 1.85+
 license-file = "LICENSE"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use this library in your Rust project, add the following to your `Cargo.toml`
 
 ```toml
 [dependencies]
-hypors = "0.3.0"
+hypors = "0.4.0"
 ```
 
 **Note** HypoRS relies on the following dependencies, which will be automatically included:

--- a/src/chi_square/variance.rs
+++ b/src/chi_square/variance.rs
@@ -1,4 +1,4 @@
-use crate::common::{TailType, TestResult, calculate_chi2_ci, calculate_p};
+use crate::common::{StatError, TailType, TestResult, calculate_chi2_ci, calculate_p};
 use statrs::distribution::ChiSquared;
 use std::f64;
 
@@ -15,7 +15,7 @@ use std::f64;
 ///
 /// # Returns
 ///
-/// Returns a `Result<TestResult, String>`, where `TestResult` contains:
+/// Returns a `Result<TestResult, StatError>`, where `TestResult` contains:
 /// - `test_statistic`: The calculated Chi-Square test statistic.
 /// - `p_value`: The p-value associated with the test statistic.
 /// - `confidence_interval`: The confidence interval for the population variance.
@@ -43,7 +43,7 @@ pub fn variance<I, T>(
     pop_variance: f64,
     tail: TailType,
     alpha: f64,
-) -> Result<TestResult, String>
+) -> Result<TestResult, StatError>
 where
     I: IntoIterator<Item = T>,
     T: Into<f64>,
@@ -53,12 +53,19 @@ where
 
     let n = sample_data.len();
 
+    if sample_data.is_empty() {
+        return Err(StatError::EmptyData);
+    }
+
+    // The sample variance needs at least two points.
     if n < 2 {
-        return Err("Sample size must be at least 2.".to_string());
+        return Err(StatError::InsufficientData);
     }
 
     if !pop_variance.is_finite() || pop_variance <= 0.0 {
-        return Err("Population variance must be a positive finite number.".to_string());
+        return Err(StatError::ComputeError(
+            "Population variance must be a positive finite number".to_string(),
+        ));
     }
 
     let mean = sample_data.iter().sum::<f64>() / n as f64;
@@ -67,7 +74,8 @@ where
 
     let test_statistic = (n as f64 - 1.0) * sample_variance / pop_variance;
     let df = n as f64 - 1.0;
-    let chi_distribution = ChiSquared::new(df).map_err(|e| format!("Chi-squared error: {e}"))?;
+    let chi_distribution = ChiSquared::new(df)
+        .map_err(|e| StatError::ComputeError(format!("Chi-squared distribution error: {e}")))?;
 
     let p_value = calculate_p(test_statistic, tail.clone(), &chi_distribution);
     let reject_null = p_value < alpha;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,10 +183,10 @@
 //!
 //! ## Error Handling
 //!
-//! Most test functions return `Result<TestResult, StatError>`, where `StatError`
-//! covers empty input, insufficient data and computation failures, and `TestResult`
-//! encapsulates the outcome of the hypothesis test. `mann_whitney::u_test` and
-//! `chi_square::variance` currently return `Result<TestResult, String>` instead.
+//! Every test function returns `Result<TestResult, StatError>`. `StatError` covers
+//! empty input (`EmptyData`), too few observations for the test (`InsufficientData`)
+//! and computation failures such as a distribution that could not be constructed
+//! (`ComputeError`). `TestResult` encapsulates the outcome of the hypothesis test.
 //!
 //! ## License
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # HypoRS: A Statistical Hypothesis Testing Library
 //!
-//! `hypors` is a Rust library designed for performing a variety of hypothesis tests, including t-tests, z-tests, proportion tests, ANOVA, Chi-square tests, and Mann-Whitney tests. This library utilizes the `polars` crate for data manipulation and the `statrs` crate for statistical distributions.
+//! `hypors` is a Rust library designed for performing a variety of hypothesis tests, including t-tests, z-tests, proportion tests, ANOVA, Chi-square tests, and Mann-Whitney tests. It operates on `Vec`s, arrays and iterators of numeric types, and uses the `statrs` crate for statistical distributions.
 //!
 //! ## Overview
 //!
@@ -183,7 +183,10 @@
 //!
 //! ## Error Handling
 //!
-//! The library uses `PolarsError` to handle errors that arise during data manipulation (e.g., failure to compute mean or variance). Each test function returns a `Result<TestResult, PolarsError>` type, where `TestResult` encapsulates the outcome of the hypothesis test.
+//! Most test functions return `Result<TestResult, StatError>`, where `StatError`
+//! covers empty input, insufficient data and computation failures, and `TestResult`
+//! encapsulates the outcome of the hypothesis test. `mann_whitney::u_test` and
+//! `chi_square::variance` currently return `Result<TestResult, String>` instead.
 //!
 //! ## License
 //!

--- a/src/mann_whitney/u.rs
+++ b/src/mann_whitney/u.rs
@@ -1,4 +1,4 @@
-use crate::common::{TailType, TestResult};
+use crate::common::{StatError, TailType, TestResult};
 use statrs::distribution::{ContinuousCDF, Normal};
 
 /// Perform the Mann-Whitney U Test for comparing two independent samples.
@@ -24,7 +24,7 @@ use statrs::distribution::{ContinuousCDF, Normal};
 ///
 /// # Returns
 ///
-/// Returns a `Result<TestResult, String>`, where `TestResult` contains:
+/// Returns a `Result<TestResult, StatError>`, where `TestResult` contains:
 /// - `test_statistic`: The computed U statistic, reported as `min(U1, U2)`
 ///   (the classical tables convention). The p-value is computed from `U1`;
 ///   scipy reports `U1` as its statistic, so compare p-values, not statistics,
@@ -56,7 +56,7 @@ pub fn u_test<I, J, T, U>(
     data2: J,
     alpha: f64,
     tail_type: TailType,
-) -> Result<TestResult, String>
+) -> Result<TestResult, StatError>
 where
     I: IntoIterator<Item = T>,
     J: IntoIterator<Item = U>,
@@ -77,7 +77,7 @@ where
     let n2 = combined.iter().filter(|(_, g)| *g == 2).count() as f64;
 
     if n1 == 0.0 || n2 == 0.0 {
-        return Err("Both groups must contain at least one observation.".to_string());
+        return Err(StatError::EmptyData);
     }
 
     // Sort combined by value
@@ -132,7 +132,9 @@ where
     let mean_u = (n1 * n2) / 2.0;
     let variance_u = (n1 * n2 / 12.0) * ((total + 1.0) - tie_term / (total * (total - 1.0)));
 
-    let dist = Normal::new(0.0, 1.0).map_err(|e| format!("Normal distribution error: {e}"))?;
+    let dist = Normal::new(0.0, 1.0).map_err(|e| {
+        StatError::ComputeError(format!("Failed to create Normal distribution: {e}"))
+    })?;
 
     // p-values from u1 so one-sided tests keep their direction
     // (min(u1, u2) is sign-blind), with the 0.5 continuity

--- a/tests/chi_square.rs
+++ b/tests/chi_square.rs
@@ -4,7 +4,7 @@ mod tests_chi_square {
         chi2_sample_size_gof, chi2_sample_size_ind, chi2_sample_size_variance, goodness_of_fit,
         independence, variance,
     };
-    use hypors::common::TailType;
+    use hypors::common::{StatError, TailType};
 
     const EPSILON: f64 = 0.001; // Tolerance for floating-point comparisons
 
@@ -28,6 +28,32 @@ mod tests_chi_square {
         assert_eq!(result.alt_hypothesis, expected_alt_hypothesis);
 
         assert!(!result.reject_null);
+    }
+
+    #[test]
+    fn test_variance_errors() {
+        let empty: Vec<f64> = vec![];
+
+        // No data at all is distinct from too little data.
+        assert_eq!(
+            variance(empty, 5.0, TailType::Two, 0.05).unwrap_err(),
+            StatError::EmptyData
+        );
+
+        // The sample variance needs at least two observations.
+        assert_eq!(
+            variance(vec![1.0], 5.0, TailType::Two, 0.05).unwrap_err(),
+            StatError::InsufficientData
+        );
+
+        // A population variance that is not positive and finite has no
+        // valid chi-square statistic.
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            match variance(vec![1.0, 2.0, 3.0], bad, TailType::Two, 0.05).unwrap_err() {
+                StatError::ComputeError(msg) => assert!(msg.contains("positive finite")),
+                other => panic!("expected ComputeError for pop_variance {bad}, got {other}"),
+            }
+        }
     }
 
     #[test]

--- a/tests/mann_whitney.rs
+++ b/tests/mann_whitney.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests_mann_whitney {
-    use hypors::common::TailType;
+    use hypors::common::{StatError, TailType};
     use hypors::mann_whitney::u_test;
 
     const EPSILON: f64 = 0.0001; // For floating-point comparisons
@@ -137,7 +137,19 @@ mod tests_mann_whitney {
     #[test]
     fn test_u_test_empty_group() {
         let empty: Vec<f64> = vec![];
-        let result = u_test(empty, vec![1.0, 2.0], 0.05, TailType::Two);
-        assert!(result.is_err());
+
+        // Either group being empty is EmptyData, whichever side it is on.
+        assert_eq!(
+            u_test(empty.clone(), vec![1.0, 2.0], 0.05, TailType::Two).unwrap_err(),
+            StatError::EmptyData
+        );
+        assert_eq!(
+            u_test(vec![1.0, 2.0], empty.clone(), 0.05, TailType::Two).unwrap_err(),
+            StatError::EmptyData
+        );
+        assert_eq!(
+            u_test(empty.clone(), empty, 0.05, TailType::Two).unwrap_err(),
+            StatError::EmptyData
+        );
     }
 }


### PR DESCRIPTION
Bumps to 0.4.0, unifies the error type, adds a CHANGELOG, corrects stale crate documentation, and adds the release workflow. Nothing publishes on merging this — publishing happens when a `v*` tag is pushed, and then only after you approve it.

## Unified error type (breaking)

Eight of the ten test functions already returned `Result<TestResult, StatError>`; `mann_whitney::u_test` and `chi_square::variance` returned `Result<TestResult, String>`. Anyone handling errors across the crate had to deal with two unrelated types, and only one of them implements `std::error::Error`.

Both now return `StatError`, following the same mapping the other eight use: `EmptyData` for empty input, `InsufficientData` for too few observations, `ComputeError` for validation and distribution-construction failures. All 19 public functions are now consistent.

`chi_square::variance` also previously collapsed empty and single-observation input into one `"Sample size must be at least 2."` string; it now distinguishes them the way the t and z tests do.

Breaking only for code that matches on the error type — `?` and `unwrap()` are unaffected. Doing it here because 0.4.0 is already a breaking release, so it costs downstream users nothing extra.

## Why 0.4.0 and not 0.3.1

For a pre-1.0 crate Cargo treats the **minor** position as the breaking one: `^0.3` will not resolve to `0.4`. That's exactly what this release needs. The Mann-Whitney p-values changed in #7, so anyone depending on `hypors = "0.3"` keeps the old numbers until they deliberately upgrade, rather than having their statistical results shift under them on a `cargo update`.

Scope was taken from the commits since the `v0.3.0` tag (PRs #7, #8, #9). I checked the published crate rather than assuming: crates.io 0.3.0 already lists only `serde` and `statrs`, so the polars removal shipped in 0.3.0 and isn't part of this entry.

## Release workflow

Fires on `v*` tags, never on a merge to `main` — a crates.io publish cannot be undone (a version can be yanked, never replaced or reused), so releasing stays deliberate rather than a side effect of merging.

**`verify` job** — checks the tag matches `Cargo.toml` before anything else (a mismatched tag would otherwise publish the wrong version or fail mid-release), then runs the full suite and `cargo package`.

**`publish` job** — bound to the `crates-io` environment, so it pauses for a required reviewer and the registry token is readable only by that job. Publishes, then creates a GitHub Release with notes taken from the matching CHANGELOG section.

### Setup needed before the first tag

The environment gate only exists once it is configured. Under **Settings → Environments**, create `crates-io`, add yourself under **Required reviewers**, and add `CARGO_REGISTRY_TOKEN` as an **environment secret there** — not as a repository secret. A repository-level secret would be readable by the job without the approval gate, which defeats the point. If the environment is missing entirely, GitHub creates it implicitly with no protection rules; the publish would then fail for lack of a token, which is at least a safe failure rather than an unapproved release.

## Documentation corrections

These are the crates.io and docs.rs front page, so they were about to be published as-is.

- **`src/lib.rs:3`** claimed the crate "utilizes the `polars` crate for data manipulation". It hasn't since 0.3.0, so it described a dependency users would never find.
- **The Error Handling section** documented `Result<TestResult, PolarsError>`, a return type no function in the crate has ever had. It now describes `StatError` and its three variants.
- **`README.md:40`** still pinned `hypors = "0.3.0"` in the install snippet.

Left alone deliberately: the "Usage with Polars" sections in both files are correct — they explain converting a `Series` to `Vec`, which is still the supported path — and `hypopy` keeps its own `0.2.1` version and real polars dependency, being a separate package excluded from the published crate.

## Verification

Error variants were checked behaviourally, not just for compilation — a scratch binary asserting that empty input yields `EmptyData`, a single observation `InsufficientData`, and a negative population variance a `ComputeError` carrying the right message.

The two release-workflow shell steps, which would otherwise only fail at release time, were run locally:

- Version guard: `v0.4.0` accepted; `v0.3.0` and `v1.2.3` rejected against the 0.4.0 manifest.
- Changelog extractor: pulls exactly the 0.4.0 section with no bleed from the 0.3.0 heading below it, and yields nothing for an unknown version, taking the `--generate-notes` fallback.

Plus the usual, as CI runs them: `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, 9 suites green including all 46 doctests, `cargo doc --no-deps` with no warnings, and `cargo package` verifying 42 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf