### PR TITLE
Let the release workflow accept a tag created from the GitHub UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,17 @@ jobs:
             found && /^## \[/ { exit }
             found { print }
           ' CHANGELOG.md > release-notes.md
-          if [ -s release-notes.md ]; then
+          # The tag may arrive either from `git push origin vX.Y.Z`, where no
+          # release exists yet, or from "Draft a new release" in the UI, which
+          # creates the tag and the release together. Handle both: `gh release
+          # create` fails outright on an existing release.
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            if [ -s release-notes.md ]; then
+              gh release edit "$GITHUB_REF_NAME" --notes-file release-notes.md
+            else
+              echo "No CHANGELOG section for $GITHUB_REF_NAME; leaving the existing notes alone."
+            fi
+          elif [ -s release-notes.md ]; then
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
           else
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,23 +68,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          notes="${RUNNER_TEMP:-/tmp}/release-notes.md"
           awk -v tag="${GITHUB_REF_NAME#v}" '
             $0 ~ "^## \\[" tag "\\]" { found = 1; next }
             found && /^## \[/ { exit }
             found { print }
-          ' CHANGELOG.md > release-notes.md
+          ' CHANGELOG.md > "$notes"
           # The tag may arrive either from `git push origin vX.Y.Z`, where no
           # release exists yet, or from "Draft a new release" in the UI, which
           # creates the tag and the release together. Handle both: `gh release
           # create` fails outright on an existing release.
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            if [ -s release-notes.md ]; then
-              gh release edit "$GITHUB_REF_NAME" --notes-file release-notes.md
+            if [ -s "$notes" ]; then
+              gh release edit "$GITHUB_REF_NAME" --notes-file "$notes"
             else
               echo "No CHANGELOG section for $GITHUB_REF_NAME; leaving the existing notes alone."
             fi
-          elif [ -s release-notes.md ]; then
-            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+          elif [ -s "$notes" ]; then
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file "$notes"
           else
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
           fi


### PR DESCRIPTION
Fixes a footgun in the release workflow from #10, found before it could bite.

## The problem

The tag can reach the workflow two ways:

- `git push origin v0.4.0` — creates a tag with no release attached. The workflow creates the release.
- **Releases → Draft a new release → Create new tag on publish** — the only way to make a tag from the GitHub UI, since there's no standalone create-a-tag button. This creates the tag *and* the release together.

On the second route the release already exists when the workflow runs, and `gh release create` fails on an existing release. The `publish` job would have published to crates.io and *then* gone red on its final step — a half-completed release, which is the most annoying kind to unpick given a crates.io version can never be reused.

## The fix

The step now checks whether the release exists first:

| tag route | CHANGELOG section | result |
|---|---|---|
| CLI push | present | `gh release create` with the CHANGELOG notes |
| UI release | present | `gh release edit` — notes replaced from the CHANGELOG |
| CLI push | absent | `gh release create --generate-notes` |
| UI release | absent | left alone, with a log line |

That last row is deliberate: if you wrote your own notes in the UI and no CHANGELOG section matches, they're kept rather than overwritten with generated ones.

The extracted notes are also written to `$RUNNER_TEMP` rather than into the checkout. Testing the original version ran its `awk` redirect in the working tree and left an empty `release-notes.md` behind, which briefly got committed here and would have shipped inside the packaged crate. Writing outside the checkout means running the step can't touch the working tree at all.

## Verification

The `run:` body was extracted from the workflow YAML programmatically and executed against a stubbed `gh`, so all four rows above are demonstrated rather than reasoned about — not a re-typed approximation of the script, the script itself. Re-run after the temp-dir change: same four outcomes, and `git status` clean afterwards.

`cargo fmt --check` clean, 9 suites green, and `cargo package` back to 42 files with no stray. No Rust code is touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf