### PR TITLE
Add an Unreleased heading to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 While this crate is pre-1.0, the **minor** version carries breaking changes:
 a dependency on `0.3` will not resolve to `0.4`.
 
+## [Unreleased]
+
+Nothing yet. Add entries here as they land; move them under a new version
+heading when releasing, since the release workflow takes its GitHub Release
+notes from the section matching the tag.
+
 ## [0.4.0] - 2026-09-07
 
 ### Changed


### PR DESCRIPTION
Follow-up to the 0.4.0 release. Gives entries somewhere to accumulate between releases, so the next version section is assembled as work lands rather than reconstructed from the commit log at tag time.

The note under the heading says to move entries under a new version heading when releasing, since the release workflow takes its GitHub Release notes from the section matching the tag — worth stating inline so the next person doesn't have to read the workflow to find that out.

## The extractor still behaves

The release workflow's `awk` only starts capturing at the heading matching the tag, so a section above the newest version is skipped rather than picked up. Verified against the updated file:

| tag | extracted |
|---|---|
| `0.4.0` | 47 lines, starting at `### Changed` — no Unreleased text, no 0.3.0 bleed |
| `0.3.0` | 3 lines, its own section |
| `9.9.9` | 0 lines → `--generate-notes` fallback |

`cargo package` verifies clean and still ships the CHANGELOG.

## Not included

The `crates-io` environment still doesn't gate the publish job — on the 0.4.0 release the publish job went from created to started in 2 seconds, so no approval was required. That's a repository setting rather than a code change, so it isn't fixable here: worth adding yourself under Required reviewers on that environment, and confirming the token is an environment secret rather than a repository one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf)_