### PR TITLE
Release 0.4.1 so the Python package has a tag to ship from

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,19 @@ jobs:
       - name: Versions agree with the tag
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
+          # A tag from before a manifest existed cannot release it, and the
+          # version comparison below would report a confusing empty mismatch.
+          missing=0
+          for file in Cargo.toml python/Cargo.toml python/pyproject.toml; do
+            if [ ! -f "$file" ]; then
+              echo "::error::$file does not exist at $TAG, so $TAG cannot release it"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || exit 1
+
           crate="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
           binding="$(cargo metadata --no-deps --format-version 1 --manifest-path python/Cargo.toml | jq -r '.packages[0].version')"
           pyproject="$(grep -m1 '^version = ' python/pyproject.toml | cut -d'"' -f2)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ a dependency on `0.3` will not resolve to `0.4`.
 
 ## [Unreleased]
 
+Nothing yet. Add entries here as they land; move them under a new version
+heading when releasing, since the release workflow takes its GitHub Release
+notes from the section matching the tag.
+
+## [0.4.1] - 2026-09-13
+
+The first release of the Python package. It ships at 0.4.1 rather than 0.4.0
+because versions track the crate, and the `v0.4.0` tag predates the bindings —
+there is no Python package in that tree to publish.
+
 ### Added
 
 - **Python bindings** (`python/`), published to PyPI as `hypors` and versioned

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hypors"
 authors = ["Shubhankar Agrawal <shubhankar.a31@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.85"        # edition 2024 requires 1.85+
 license-file = "LICENSE"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hypors-py"
 authors = ["Shubhankar Agrawal <shubhankar.a31@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hypors"
-version = "0.4.0"
+version = "0.4.1"
 description = "Hypothesis testing for Python, backed by the hypors Rust crate"
 readme = "README.md"
 authors = [{ name = "Shubhankar Agrawal", email = "shubhankar.a31@gmail.com" }]


### PR DESCRIPTION
Fixes the failed release dispatch. Nothing was published and no approval was consumed — the guard stopped it in `verify` after 10 seconds.

## What happened

```
error: manifest path `python/Cargo.toml` does not exist
grep: python/pyproject.toml: No such file or directory
tag=0.4.0 crate=0.4.0 binding= pyproject=
```

`v0.4.0` points at `14c2c06`, merged 7 September — **before the bindings existed**. There is no `python/` directory in that tree, so there is no Python package there to publish. My instruction to dispatch against `v0.4.0` was wrong; the workflow behaved correctly.

Reusing the tag isn't an option either: moving a tag that crates.io 0.4.0 was already published from would misrepresent what that release contained.

## The fix

All three manifests go to **0.4.1**, so both registries get a version whose tree actually contains both libraries.

Why a patch bump: the crate's only change since 0.4.0 is dropping the unused `cdylib`, which is a packaging change, not an API one. The Python package makes its first release at 0.4.1 to stay in lockstep — its changelog entry says so explicitly, since a first release at `.1` invites the question.

## Guard improvement

The check caught this, but reported it as `python/Cargo.toml is  but the tag is 0.4.0` — an empty-string mismatch that says nothing about the cause. It now verifies each manifest exists first:

```
ERROR: python/Cargo.toml does not exist at v0.4.0, so v0.4.0 cannot release it
ERROR: python/pyproject.toml does not exist at v0.4.0, so v0.4.0 cannot release it
```

Tested both ways — against the current tree, and against a worktree checked out at `v0.4.0`, which is the exact tree that just failed.

## Verification

- Version guard accepts 0.4.1 with all three manifests agreeing; rejects the v0.4.0 tree by name.
- crates.io returns 404 for 0.4.1, so both registries will publish this time rather than skip.
- CHANGELOG extraction for 0.4.1 pulls its own 33-line section with no bleed from `[Unreleased]`.
- Both crates fmt/clippy clean, 9 Rust suites green, `cargo package` 42 files, wheel builds and reports `0.4.1`, 45 pytest tests pass.

## After merging

Tag `v0.4.1` on `main` and push it — no dispatch needed this time, since the tag will point at a tree containing both. Then two approvals: `crates-io` (publishes 0.4.1 for real now) and `pypi` (publishes `hypors` 0.4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf)_