### PR TITLE
Qualify submodule names, make the result types picklable, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Action versions go stale silently — a deprecation warning in a log is easy
+# to miss, and the release workflow only runs at release time, which is the
+# worst moment to discover a pinned action has been retired.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: cargo
+    directory: /python
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "deps"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,20 @@ a dependency on `0.3` will not resolve to `0.4`.
 
 ## [Unreleased]
 
-Nothing yet. Add entries here as they land; move them under a new version
-heading when releasing, since the release workflow takes its GitHub Release
-notes from the section matching the tag.
+### Fixed
+
+- Python submodules report a fully qualified `__name__`. `hypors.t` called
+  itself `t`, which named a module that could not be imported back and showed
+  up that way in every repr and traceback.
+- `TestResult` and `TailType` can be pickled and copied. Neither could before,
+  so a result could not be cached to disk or returned from a
+  `multiprocessing` pool, and `copy.deepcopy` failed on both.
+
+### Added
+
+- Dependabot keeps GitHub Actions and both Cargo manifests current. Action
+  deprecations otherwise surface only as a warning in a log, and the release
+  workflow runs at the worst possible moment to discover a retired action.
 
 ## [0.4.1] - 2026-09-13
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -22,7 +22,8 @@ fn add_submodule(
     register: fn(&Bound<'_, PyModule>) -> PyResult<()>,
 ) -> PyResult<()> {
     let py = parent.py();
-    let module = PyModule::new(py, name)?;
+    // Fully qualified, so the module reports hypors.t rather than t.
+    let module = PyModule::new(py, &format!("hypors.{name}"))?;
     register(&module)?;
     parent.add_submodule(&module)?;
     py.import("sys")?

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -1,6 +1,7 @@
 //! The two types crossing the boundary in both directions.
 
 use hypors::common::{TailType as RsTailType, TestResult as RsTestResult};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -29,6 +30,24 @@ impl TailType {
 
     fn __repr__(&self) -> String {
         format!("TailType.{}", self.name())
+    }
+
+    /// Rebuild a variant from its name, so the type can be pickled.
+    #[staticmethod]
+    fn _from_name(name: &str) -> PyResult<TailType> {
+        match name {
+            "Left" => Ok(TailType::Left),
+            "Right" => Ok(TailType::Right),
+            "Two" => Ok(TailType::Two),
+            other => Err(PyValueError::new_err(format!("unknown TailType: {other}"))),
+        }
+    }
+
+    // Without this the type cannot be pickled or copied, which breaks passing
+    // a tail across a multiprocessing pool.
+    fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (String,))> {
+        let from_name = slf.as_any().get_type().getattr("_from_name")?.unbind();
+        Ok((from_name, (slf.get().name().to_string(),)))
     }
 }
 
@@ -111,6 +130,24 @@ impl TestResult {
         dict.set_item("alt_hypothesis", &self.alt_hypothesis)?;
         dict.set_item("reject_null", self.reject_null)?;
         Ok(dict)
+    }
+
+    // A result is exactly the sort of value that gets cached to disk or sent
+    // between processes, so it has to survive pickle and copy.
+    fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (f64, f64, (f64, f64), String, String, bool))> {
+        let cls = slf.as_any().get_type().unbind().into_any();
+        let r = slf.get();
+        Ok((
+            cls,
+            (
+                r.test_statistic,
+                r.p_value,
+                r.confidence_interval,
+                r.null_hypothesis.clone(),
+                r.alt_hypothesis.clone(),
+                r.reject_null,
+            ),
+        ))
     }
 
     fn __repr__(&self) -> String {

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -5,6 +5,9 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+/// The arguments `TestResult.__new__` takes, in order.
+type TestResultArgs = (f64, f64, (f64, f64), String, String, bool);
+
 /// Which tail of the distribution a test is run against.
 #[pyclass(eq, eq_int, frozen, from_py_object, module = "hypors.common")]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -134,7 +137,7 @@ impl TestResult {
 
     // A result is exactly the sort of value that gets cached to disk or sent
     // between processes, so it has to survive pickle and copy.
-    fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (f64, f64, (f64, f64), String, String, bool))> {
+    fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, TestResultArgs)> {
         let cls = slf.as_any().get_type().unbind().into_any();
         let r = slf.get();
         Ok((

--- a/python/tests/test_common.py
+++ b/python/tests/test_common.py
@@ -77,3 +77,49 @@ def test_test_result_inequality():
         reject_null=False,
     )
     assert make_result() != other
+
+
+def test_submodules_are_fully_qualified():
+    # A bare __name__ of "t" names a module that cannot be imported back,
+    # and shows up in every repr and traceback.
+    import hypors.anova
+    import hypors.chi_square
+    import hypors.mann_whitney
+    import hypors.proportion
+    import hypors.t
+    import hypors.z
+
+    for module, expected in [
+        (hypors.anova, "hypors.anova"),
+        (hypors.chi_square, "hypors.chi_square"),
+        (hypors.mann_whitney, "hypors.mann_whitney"),
+        (hypors.proportion, "hypors.proportion"),
+        (hypors.t, "hypors.t"),
+        (hypors.z, "hypors.z"),
+    ]:
+        assert module.__name__ == expected
+
+
+def test_test_result_survives_pickle_and_copy():
+    # Results get cached to disk and sent across process pools.
+    import copy
+    import pickle
+
+    result = make_result()
+    assert pickle.loads(pickle.dumps(result)) == result
+    assert copy.copy(result) == result
+    assert copy.deepcopy(result) == result
+
+
+def test_tail_type_survives_pickle_and_copy():
+    import copy
+    import pickle
+
+    for tail in (TailType.Left, TailType.Right, TailType.Two):
+        assert pickle.loads(pickle.dumps(tail)) == tail
+        assert copy.deepcopy(tail) == tail
+
+
+def test_tail_type_from_name_rejects_nonsense():
+    with pytest.raises(ValueError, match="unknown TailType"):
+        TailType._from_name("Sideways")


### PR DESCRIPTION
Housekeeping after the 0.4.1 release. No version bump — nothing is being published yet.

Looking at the *published* package rather than the source turned up two real defects, neither of which was on the list.

## Submodules had a bare `__name__`

```python
>>> import hypors.t
>>> hypors.t
<module 't'>
>>> hypors.t.__name__
't'
```

`t` names a module that can't be imported back, and it appeared that way in every repr and traceback. They're now registered as `hypors.<name>`, matching the key they were already given in `sys.modules`.

## Neither result type could be pickled or copied

```python
>>> pickle.dumps(result)
TypeError: cannot pickle 'hypors.common.TestResult' object
>>> copy.deepcopy(result)
TypeError: cannot pickle 'hypors.common.TestResult' object
```

Both `TestResult` and `TailType` failed, and so did `copy.copy` and `copy.deepcopy`, which route through the same protocol. That rules out caching a result to disk, returning one from a `multiprocessing` pool, or deepcopying either type — all ordinary things to do with a results object, and the sort of thing a stats user hits the first time they parallelise a bootstrap.

Both now implement `__reduce__`. `TestResult` reduces through its existing constructor. `TailType` needed a `_from_name` lookup first, since a fieldless enum has nothing to rebuild from.

## Dependabot

`.github/dependabot.yml` covering GitHub Actions and both Cargo manifests, monthly. An action deprecation otherwise surfaces only as a warning buried in a log — the `actions/setup-python@v5` Node 20 notice is sitting in the last release run — and the release workflow runs at the worst possible moment to discover a pinned action has been retired. This also settles that warning without me guessing at a version I couldn't verify from here.

## Tests

Four added, pinning each fix: fully qualified names across all six submodules, pickle and copy round-trips for `TestResult`, the same for all three `TailType` variants, and `_from_name` rejecting nonsense. 45 → 49 tests.

## A correction to my own push

I pushed the first commit having misread a chained verification run as passing — it wasn't. `cargo fmt` wanted the long `__reduce__` signature wrapped, and `clippy::type_complexity` rejected its inline six-element return tuple. The second commit fixes both, naming the tuple `TestResultArgs` after what it actually is: the arguments `TestResult.__new__` takes, in order. I've since re-run each check individually rather than chained, so each result is read on its own.

Verified: both crates fmt and clippy clean under `-D warnings`, 9 Rust suites green, `cargo package` 42 files, wheel builds, 49 pytest tests pass.

## Not included: type stubs

I listed `.pyi` stubs as a nit earlier. Having looked properly, they aren't one — and the reason is worth recording.

maturin builds this as a package (`hypors/__init__.py` plus `hypors.abi3.so`), so `py.typed` has somewhere valid to live. But the submodules are injected into `sys.modules` at import time from Rust, and a static type checker cannot see that: `from hypors.t import t_test` would stay unresolved no matter what `__init__.pyi` says. Stubbing it properly means shipping a real package directory with a `.pyi` per submodule, which means switching to maturin's mixed layout via `python-source` — a change to how the wheel is assembled, with import breakage as the failure mode.

Worth doing, but as its own change with its own verification, not bolted onto a housekeeping PR. Happy to take it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZcqRWxKkoapY1oWnDNHpf)_